### PR TITLE
Typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ aws cloudformation deploy --template-file example/template.yaml --stack-name Sfn
 STATE_MACHINE=$(aws cloudformation describe-stacks --stack-name SfnCallbackUrlsExample --query "Stacks[0].Outputs[?OutputKey=='StateMachine'].OutputValue" --output text)
 
 # Run the example state machine
-aws step-functions start-execution --state-machine-arn $STATE_MACHINE --input "{\"name\": \"$NAME\"}"
+aws stepfunctions start-execution --state-machine-arn $STATE_MACHINE --input "{\"name\": \"$NAME\"}"
 
 # Now you will get an approve/reject email, followed by a confirmation of the same
 

--- a/example/README.md
+++ b/example/README.md
@@ -20,5 +20,5 @@ aws cloudformation deploy --template-file template.yaml --stack-name $EXAMPLE_ST
 
 STATE_MACHINE=$(aws cloudformation describe-stacks --stack-name $EXAMPLE_STACK_NAME --query "Stacks[0].Outputs[?OutputKey=='StateMachine'].OutputValue" --output text)
 
-aws step-functions start-execution --state-machine-arn $STATE_MACHINE --input "{\"name\": \"$NAME\"}"
+aws stepfunctions start-execution --state-machine-arn $STATE_MACHINE --input "{\"name\": \"$NAME\"}"
 ```


### PR DESCRIPTION
In the aws cli the service name for Step Functions is `stepfunctions`.

https://docs.aws.amazon.com/cli/latest/reference/stepfunctions/index.html